### PR TITLE
Added uptime-kuma v1.23.13 as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "uptime-kuma"]
+	path = uptime-kuma
+	url = git@github.com:louislam/uptime-kuma.git
+	branch = master

--- a/zerops.yml
+++ b/zerops.yml
@@ -3,11 +3,10 @@ zerops:
     build:
       base: nodejs@20
       buildCommands:
-        - git clone https://github.com/louislam/uptime-kuma temp_dir && \mv temp_dir/* temp_dir/.[!.]* ./ || true && \rm -rf temp_dir
         - npm ci
         - npm run build
       deployFiles:
-        - ./
+        - ./uptime-kuma/~/
     run:
       base: nodejs@20
       envVariables:


### PR DESCRIPTION
To clone the repo with submodule correctly you need to do `git clone --recurse-submodules`

Or if you already had repo cloned, you need to run `git submodule update --init` after you pulled the changes.